### PR TITLE
fix: handling of control messages

### DIFF
--- a/pyess/essmqtt.py
+++ b/pyess/essmqtt.py
@@ -164,7 +164,7 @@ async def _main(arguments=None):
             async for msg in messages:
                 logger.info(f"control message received {msg}")
                 try:
-                    state = strtobool(msg.decode())
+                    state = strtobool(msg.payload.decode())
                     await control(state)
                 except ValueError:
                     logger.warning(f"ignoring incompatible value {msg} for switching")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='pyess',
       packages=['pyess'],
 
       install_requires=[
-          'zeroconf', 'requests', 'graphyte', 'aiohttp', 'asyncio-mqtt>=0.3.0', 'ConfigArgParse'
+          'zeroconf', 'requests', 'graphyte', 'aiohttp', 'asyncio-mqtt>=0.4.0', 'ConfigArgParse'
       ],
 
       zip_safe=False,


### PR DESCRIPTION
Version 0.4.0 of asyncio-mqtt introduces an unannounced breaking change
which requires to use msg.payload to get to the string value. Allowing
\>=0.3.0 in setup.py installs 0.4.0 or greater which breaks.